### PR TITLE
RSA-Siggen

### DIFF
--- a/examples/rsa/capabilities/3511-RSA_sigGen_FIPS186-4.json
+++ b/examples/rsa/capabilities/3511-RSA_sigGen_FIPS186-4.json
@@ -1,6 +1,8 @@
 {
     "algorithm": "RSA",
     "revision": "FIPS186-4",
+    "pubExpMode": "fixed",
+    "fixedPubExp": "010001",
     "capabilities": [
         {
             "sigType": "pkcs1v1.5",

--- a/examples/rsa/capabilities/3514-RSA_keyGen_FIPS186-4.json
+++ b/examples/rsa/capabilities/3514-RSA_keyGen_FIPS186-4.json
@@ -6,7 +6,7 @@
     "fixedPubExp": "010001",
     "capabilities": [
         {
-            "randPQ": "B.3.3",
+            "randPQ": "B.3.6",
             "properties": [
                 {
                     "modulo": 2048,

--- a/examples/rsa/capabilities/3515-RSA_keyGen_FIPS186-4.json
+++ b/examples/rsa/capabilities/3515-RSA_keyGen_FIPS186-4.json
@@ -5,24 +5,13 @@
     "pubExpMode": "random",
     "capabilities": [
         {
-            "randPQ": "B.3.3",
+            "randPQ": "B.3.6",
             "properties": [
-                {
-                    "modulo": 2048,
-                    "primeTest": [
-                        "tblC2"
-                    ]
-                },
                 {
                     "modulo": 3072,
                     "primeTest": [
-                        "tblC2"
-                    ]
-                },
-                {
-                    "modulo": 4096,
-                    "primeTest": [
-                        "tblC2"
+                        "tblC2" ,
+			"tblC3"
                     ]
                 }
             ]

--- a/rsa.c
+++ b/rsa.c
@@ -526,6 +526,8 @@ int ACVP_TEST_vs_rsa_siggen_fips186_4(cJSON *j, void *options, cJSON *out)  {
                || !pkey_get_bn_bytes(rsa_pkey, OSSL_PKEY_PARAM_RSA_E, &e, &e_len))
                     goto error_die;
 
+            
+
             /* Dump out the properties of the keys we are using */
 #ifdef TRACE
             printf("N: ");
@@ -561,6 +563,7 @@ int ACVP_TEST_vs_rsa_siggen_fips186_4(cJSON *j, void *options, cJSON *out)  {
                 char *padding = OSSL_PKEY_RSA_PAD_MODE_NONE;
                 if(!strcasecmp(sigType->valuestring, "pkcs1v1.5")) padding = OSSL_PKEY_RSA_PAD_MODE_PKCSV15;
                 if(!strcasecmp(sigType->valuestring, "pss"))        padding = OSSL_PKEY_RSA_PAD_MODE_PSS;
+                if(!strcasecmp(sigType->valuestring, "ansx9.31"))        padding = OSSL_PKEY_RSA_PAD_MODE_X931;
 
                 OSSL_PARAM params[4] = {0}, *p = params;
                 *(p++) = OSSL_PARAM_construct_utf8_string(OSSL_SIGNATURE_PARAM_PAD_MODE, padding, 0);


### PR DESCRIPTION
Update RSA-SigGen to include support for ansx.931 padding mode.

Modified example capabilities for RSA SigGen and KeyGen to reflect the harnesses capabilities.